### PR TITLE
ALU: Fix custom gates

### DIFF
--- a/qunetsim/backends/pyqrack_backend.py
+++ b/qunetsim/backends/pyqrack_backend.py
@@ -289,7 +289,7 @@ class PyQrackBackend(object):
             qubit(Qubit): Qubit to which the gate is applied.
             gate(np.ndarray): 2x2 array of the gate.
         """
-        self.engine.mtrx([gate[0].real, gate[0].imag, gate[1].real, gate[1].imag, gate[2].real, gate[2].imag, gate[3].real, gate[3].imag], qubit.qubit)
+        self.engine.mtrx(gate.flatten().tolist(), qubit.qubit)
 
     def custom_controlled_gate(self, qubit, target, gate):
         """
@@ -300,7 +300,7 @@ class PyQrackBackend(object):
             target(Qubit): Qubit on which the gate is applied.
             gate(nd.array): 2x2 array for the gate applied to target.
         """
-        self.engine.mcmtrx([qubit], [gate[0].real, gate[0].imag, gate[1].real, gate[1].imag, gate[2].real, gate[2].imag, gate[3].real, gate[3].imag], qubit.qubit)
+        self.engine.mcmtrx([qubit], gate.flatten().tolist(), qubit.qubit)
 
     def custom_two_qubit_gate(self, qubit1, qubit2, gate):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyqrack
+numpy
 qunetsim


### PR DESCRIPTION
The custom gate API was broken. This fixes it, according to the `pyqrack==0.3.0` API, which should be on `pypi` tonight.